### PR TITLE
update eol_sso interface

### DIFF
--- a/eol_sso/services/interface.py
+++ b/eol_sso/services/interface.py
@@ -3,6 +3,7 @@ import logging
 
 # Installed packages (via pip)
 from django.apps import apps
+from django.contrib.auth.models import User
 if apps.is_installed('uchileedxlogin'):
     from uchileedxlogin.services.interface import (
         get_doc_id_by_user_id as uchileedxlogin_get_doc_id_by_user_id,
@@ -12,7 +13,6 @@ if apps.is_installed('uchileedxlogin'):
         PhApiException as UchileedxloginPhApiException,
         EmailException as UchileedxloginEmailException
     )
-    from uchileedxlogin.services.utils import get_document_type as uchileedxlogin_get_document_type
     MODEL_USED = 'uchileedxlogin'
 elif apps.is_installed('eol_sso_login'):
     from eol_sso_login.models import SSOLoginExtraData
@@ -35,38 +35,51 @@ class EmailException(Exception):
     edx user.
     """
 
-def get_doc_id_by_user_id(user_id):
+def get_indiv_id(user_id):
     """
-    Return the document id associated with the user. If there is not a user with that id, returns None.
+    Gets the indiv_id associated with user_id.
+    Note: Documents of type DNI are not considered in the case of eol_sso_login since eol_sso
+    doesn't support that type. Therefore, if a user has an indiv_id of that type, it's going to
+    return None.
     """
     if MODEL_USED == 'uchileedxlogin':
         return uchileedxlogin_get_doc_id_by_user_id(user_id)
     elif MODEL_USED == 'eol_sso_login':
         try:
-            doc_id = SSOLoginExtraData.objects.values_list('document', flat=True).get(user__id=user_id)
-            return doc_id
+            indiv_id = SSOLoginExtraData.objects.values_list('document').get(type_document__in=['rut', 'passport'], user__id=user_id)
+            return indiv_id
         except SSOLoginExtraData.DoesNotExist:
             return None
 
-def get_user_id_doc_id_pairs(user_ids):
+def get_user_id_with_indiv_id_list(user_id_list):
     """
-    Returns a list containing the pairs user_id/doc_id associated with the users in user_ids.
+    Returns a list containing pairs user_id/indiv_id associated with the users in user_id_list.
+    Note: Documents of type DNI are not considered in the case of eol_sso_login since eol_sso
+    doesn't support that type. Therefore, if a user has an indiv_id of that type, it's going
+    to return None.
     """
     if MODEL_USED == 'uchileedxlogin':
-        return uchileedxlogin_get_user_id_doc_id_pairs(user_ids)
+        return uchileedxlogin_get_user_id_doc_id_pairs(user_id_list)
     elif MODEL_USED == 'eol_sso_login':
-        users_doc_id_pairs = SSOLoginExtraData.objects.filter(user__id__in=user_ids).values_list('user__id', 'document')
-        return users_doc_id_pairs
+        user_id_with_indiv_id_list = SSOLoginExtraData.objects.filter(type_document__in=['rut', 'passport'], user__id__in=user_id_list).values_list('user__id', 'document')
+        return user_id_with_indiv_id_list
 
-def get_user_by_doc_id(doc_id, doc_type):
+def get_user_by_indiv_id(indiv_id):
     """
-    Get the user associated with doc_id, if it doesn't exists, return None.
-    Doesn't work with eol_sso_login.
+    Get the user associated with indiv_id, if it doesn't exist, return None.
     """
     if MODEL_USED == 'uchileedxlogin':
-        return uchileedxlogin_get_user_by_doc_id(doc_id)
+        edxloginuser = uchileedxlogin_get_user_by_doc_id(indiv_id)
+        if edxloginuser is None:
+            return None
+        else:
+            return edxloginuser.user
     elif MODEL_USED == 'eol_sso_login':
-        raise NotImplementedError("Not supported")
+        try:
+            user = User.objects.get(ssologinextradata__document=indiv_id, ssologinextradata__type_document__in=['rut', 'passport'])
+            return user
+        except User.DoesNotExist:
+            return None
 
 def sso_user_factory(value, value_type):
     """
@@ -85,16 +98,3 @@ def sso_user_factory(value, value_type):
             raise EmailException()
     else:
         raise NotImplementedError("Not supported")
-
-def get_document_type(doc_id):
-    """
-    Get the document type of a document id.
-    """
-    if MODEL_USED == 'uchileedxlogin':
-        return uchileedxlogin_get_document_type(doc_id)
-    elif MODEL_USED == 'eol_sso_login':
-        try:
-            document_type = SSOLoginExtraData.objects.get(document=doc_id).type_document
-            return document_type
-        except SSOLoginExtraData.DoesNotExist:
-            return None

--- a/eol_sso/services/tests_eol_sso_login.py
+++ b/eol_sso/services/tests_eol_sso_login.py
@@ -3,15 +3,16 @@
 import logging
 
 # Installed packages (via pip)
+from django.contrib.auth.models import User
 from django.test import TestCase
-from mock import Mock, patch
+from mock import patch
 from eol_sso_login.models import SSOLoginExtraData
 
 # Edx dependencies
 from student.tests.factories import UserFactory
 
 # Internal project dependencies
-from eol_sso.services.interface import get_document_type, get_doc_id_by_user_id, get_user_id_doc_id_pairs
+from eol_sso.services.interface import get_indiv_id, get_user_by_indiv_id, get_user_id_with_indiv_id_list
 
 logger = logging.getLogger(__name__)
 
@@ -23,60 +24,66 @@ class EolSsoInterfaceTests(TestCase):
         # to create a new cc user when creating a django user
         with patch('student.models.cc.User.save'):
             self.user = UserFactory(username='student', email='student@edx.org')
-            self.user2 = UserFactory(username='student2', email='student2@edx.org')
 
     @patch('eol_sso.services.interface.SSOLoginExtraData.objects')
-    def test_get_doc_id_by_user_id_none_return_value(self, mock_get):
+    def test_get_indiv_id_none_return_value(self, mock_get):
         """
-        Test get_doc_id_by_user_id when the user doesn't have extra data
+        Test get_indiv_id when the user doesn't have extra data
         """
         mock_get.values_list.return_value.get.side_effect = SSOLoginExtraData.DoesNotExist
-        doc_id = get_doc_id_by_user_id(self.user.id)
-        self.assertEqual(doc_id, None)
+        indiv_id = get_indiv_id(self.user.id)
+        self.assertEqual(indiv_id, None)
 
     @patch('eol_sso.services.interface.SSOLoginExtraData.objects')
-    def test_get_doc_id_by_user_id_doc_id_return_value(self, mock_get):
+    def test_get_indiv_id_rut(self, mock_get):
         """
-        Test get_doc_id_by_user_id when the user has extra data
+        Test get_indiv_id when the user has a indiv_id
         """
-        mock_get.values_list.return_value.get.return_value = 12345678
-        doc_id = get_doc_id_by_user_id(self.user.id)
-        self.assertEqual(doc_id, 12345678)
+        mock_get.values_list.return_value.get.return_value = '12345678'
+        indiv_id = get_indiv_id(self.user.id)
+        self.assertEqual(indiv_id, '12345678')
 
     @patch('eol_sso.services.interface.SSOLoginExtraData.objects')
-    def test_get_user_id_doc_id_pairs_empty_list_return_value(self, mock_user_doc_id_pair):
+    def test_get_indiv_id_passport(self, mock_get):
         """
-        Test get_user_id_doc_id_pairs when the user doesn't have extra data
+        Test get_indiv_id when the user has a indiv_id following the passport format
         """
-        mock_user_doc_id_pair.filter.return_value.values_list.return_value = []
-        user_id_doc_id_list = get_user_id_doc_id_pairs([self.user.id])
-        self.assertEqual(user_id_doc_id_list, [])
+        mock_get.values_list.return_value.get.return_value = 'P2345678'
+        indiv_id = get_indiv_id(self.user.id)
+        self.assertEqual(indiv_id, 'P2345678')
 
     @patch('eol_sso.services.interface.SSOLoginExtraData.objects')
-    def test_get_user_id_doc_id_pairs_pair_return_value(self, mock_user_doc_id_pair):
+    def test_get_user_id_with_indiv_id_list_empty_list_return_value(self, mock_user_doc_id_queryset):
         """
-        Test get_user_id_doc_id_pairs when the user has extra data
+        Test get_user_id_with_indiv_id_list when the user doesn't have extra data
         """
-        mock_user_doc_id_pair.filter.return_value.values_list.return_value = [(self.user.id, 1234568)]
-        user_id_doc_id_list = get_user_id_doc_id_pairs([self.user.id])
-        self.assertEqual(user_id_doc_id_list, [(self.user.id, 1234568)])
+        mock_user_doc_id_queryset.filter.return_value.values_list.return_value = []
+        user_id_doc_tuples_list = get_user_id_with_indiv_id_list([self.user.id])
+        self.assertEqual(user_id_doc_tuples_list, [])
 
     @patch('eol_sso.services.interface.SSOLoginExtraData.objects')
-    def test_get_document_type_extra_data(self, mock_get):
+    def test_get_user_id_with_indiv_id_list(self, mock_user_doc_id_queryset):
         """
-        Test get_document_type when the user has extra data
+        Test get_user_id_with_indiv_id_list when the user has extra data
         """
-        mock_query_response = Mock()
-        mock_query_response.type_document = 'run'
-        mock_get.get.return_value = mock_query_response
-        document_type = get_document_type(12346787)
-        self.assertEqual(document_type, 'run')
+        mock_user_doc_id_queryset.filter.return_value.values_list.return_value = [(self.user.id, '1234568')]
+        user_id_doc_tuples_list = get_user_id_with_indiv_id_list([self.user.id])
+        self.assertEqual(user_id_doc_tuples_list, [(self.user.id, '1234568')])
 
-    @patch('eol_sso.services.interface.SSOLoginExtraData.objects')
-    def test_get_document_type_none_return_value(self, mock_get):
+    @patch('eol_sso.services.interface.User.objects.get')
+    def test_get_user_by_indiv_id_none_return_value(self, mock_user):
         """
-        Test get_doc_id_by_user_id when the user doesn't have extra data
+        Test get_user_by_indiv_id when the indiv_id is not linked to any users
         """
-        mock_get.get.side_effect = SSOLoginExtraData.DoesNotExist
-        document_type = get_document_type(12346787)
-        self.assertEqual(document_type, None)
+        mock_user.side_effect = User.DoesNotExist
+        user = get_user_by_indiv_id('123456789')
+        self.assertEqual(user, None)
+
+    @patch('eol_sso.services.interface.User.objects.get')
+    def test_get_user_by_indiv_id_user_return_value(self, mock_response):
+        """
+        Test get_user_by_indiv_id when the indiv_id is linked to a user
+        """
+        mock_response.return_value = self.user
+        user = get_user_by_indiv_id('P123456789')
+        self.assertEqual(user, self.user)

--- a/eol_sso/services/tests_uchileedxlogin.py
+++ b/eol_sso/services/tests_uchileedxlogin.py
@@ -4,7 +4,7 @@ import logging
 
 # Installed packages (via pip)
 from django.test import TestCase
-from mock import patch
+from mock import patch, MagicMock
 from uchileedxlogin.services.interface import (
         PhApiException as UchileedxloginPhApiException,
         EmailException as UchileedxloginEmailException
@@ -14,12 +14,11 @@ from uchileedxlogin.services.interface import (
 from student.tests.factories import UserFactory
 
 # Internal project dependencies
-from eol_sso.services.interface import get_doc_id_by_user_id, get_document_type, get_user_id_doc_id_pairs, get_user_by_doc_id, sso_user_factory, PhApiException, EmailException
+from eol_sso.services.interface import get_indiv_id, get_user_id_with_indiv_id_list, get_user_by_indiv_id, sso_user_factory, PhApiException, EmailException
 
 logger = logging.getLogger(__name__)
 
 class EolSsoInterfaceTests(TestCase):
-
     def setUp(self):
         # Patch the comment client user save method so it does not try
         # to create a new cc user when creating a django user
@@ -27,61 +26,65 @@ class EolSsoInterfaceTests(TestCase):
             self.user = UserFactory(username='student', email='student@edx.org')
 
     @patch('eol_sso.services.interface.uchileedxlogin_get_doc_id_by_user_id')
-    def test_get_doc_id_by_user_id_none_return_value(self, mock_doc_id):
+    def test_get_indiv_id_none_return_value(self, mock_doc_id):
         """
-        Test get_doc_id_by_user_id when uchileedxlogin get_doc_id_by_user_id returns None.
+        Test get_indiv_id when uchileedxlogin get_doc_id returns None.
         """
         mock_doc_id.return_value = None
-        doc_id = get_doc_id_by_user_id(self.user.id)
-        self.assertEqual(doc_id, None)
+        indiv_id = get_indiv_id(self.user.id)
+        self.assertEqual(indiv_id, None)
 
     @patch('eol_sso.services.interface.uchileedxlogin_get_doc_id_by_user_id')
-    def test_get_doc_id_by_user_id_doc_id_return_value(self, mock_doc_id):
+    def test_get_indiv_id_passport_return_value(self, mock_doc_id):
         """
-        Test get_doc_id_by_user_id when uchileedxlogin get_doc_id_by_user_id returns a doc_id.
+        Test get_indiv_id when uchileedxlogin get_doc_id returns a passport.
         """
-        mock_doc_id.return_value = 12345678
-        doc_id = get_doc_id_by_user_id(self.user.id)
-        self.assertEqual(doc_id, 12345678)
+        mock_doc_id.return_value = 'P1234567'
+        indiv_id = get_indiv_id(self.user.id)
+        self.assertEqual(indiv_id, 'P1234567')
 
     @patch('eol_sso.services.interface.uchileedxlogin_get_user_id_doc_id_pairs')
-    def test_get_user_id_doc_id_pairs_empty_list_return_value(self, mock_doc_id):
+    def test_get_user_id_with_doc_empty_list_return_value(self, mock_doc_id):
         """
-        Test get_user_id_doc_id_pairs when the return value of uchileedxlogin 
+        Test get_user_id_with_doc_list when the return value of uchileedxlogin
         get_user_id_doc_id_pairs is an empty list.
         """
         mock_doc_id.return_value = []
-        user_id_doc_id_list = get_user_id_doc_id_pairs([self.user.id])
-        self.assertEqual(user_id_doc_id_list, [])
+        user_id_indiv_id_tuples_list = get_user_id_with_indiv_id_list([self.user.id])
+        self.assertEqual(user_id_indiv_id_tuples_list, [])
 
     @patch('eol_sso.services.interface.uchileedxlogin_get_user_id_doc_id_pairs')
-    def test_get_user_id_doc_id_pairs_pair_return_value(self, mock_doc_id):
+    def test_get_user_id_with_doc_pair_return_value(self, mock_doc_id):
         """
-        Test get_user_id_doc_id_pairs when the return value of uchileedxlogin
+        Test get_user_id_with_doc_list when the return value of uchileedxlogin
         get_user_id_doc_id_pairs has a pair of values.
         """
-        mock_doc_id.return_value = [(self.user.id, 1234568)]
-        user_id_doc_id_list = get_user_id_doc_id_pairs([self.user.id])
-        self.assertEqual(user_id_doc_id_list, [(self.user.id, 1234568)])
+        mock_doc_id.return_value = [(self.user.id, '1234568')]
+        user_id_indiv_id_tuples_list = get_user_id_with_indiv_id_list([self.user.id])
+        self.assertEqual(user_id_indiv_id_tuples_list, [(self.user.id, '1234568')])
 
     @patch('eol_sso.services.interface.uchileedxlogin_get_user_by_doc_id')
-    def test_get_user_by_doc_id_none_return_value(self, mock_user):
+    def test_get_user_by_indiv_id_none_return_value(self, mock_user):
         """
-        Test get_user_by_doc_id when the return value of uchileedxlogin 
+        Test get_user_by_indiv_id when the return value of uchileedxlogin 
         get_user_by_doc_id is None.
         """
         mock_user.return_value = None
-        user = get_user_by_doc_id(self.user.id, None)
+        user = get_user_by_indiv_id('123456789')
         self.assertEqual(user, None)
 
     @patch('eol_sso.services.interface.uchileedxlogin_get_user_by_doc_id')
-    def test_get_user_by_doc_id_user_return_value(self, mock_user):
+    def test_get_user_by_indiv_id_user_return_value(self, mock_user):
         """
-        Test get_user_by_doc_id when the return value of uchileedxlogin 
+        Test get_user_by_indiv_id when the return value of uchileedxlogin 
         get_user_by_doc_id is a user.
         """
-        mock_user.return_value = self.user
-        user = get_user_by_doc_id(123456789, 'rut')
+        mock_edxloginuser = MagicMock()
+        mock_edxloginuser.user = self.user
+        mock_edxloginuser.rut = '123456789'
+
+        mock_user.return_value = mock_edxloginuser
+        user = get_user_by_indiv_id('123456789')
         self.assertEqual(self.user, user)
 
     @patch('eol_sso.services.interface.uchileedxlogin_edxloginuser_factory')
@@ -111,12 +114,3 @@ class EolSsoInterfaceTests(TestCase):
         mock_edxloginuser.side_effect = UchileedxloginEmailException()
         with self.assertRaises(EmailException):
             sso_user_factory(123456789, 'doc_id')
-
-    @patch('eol_sso.services.interface.uchileedxlogin_get_document_type')
-    def test_get_document_type(self, mock_get):
-        """
-        Test get_document_type for some document_id
-        """
-        mock_get.return_value = 'run'
-        document_type = get_document_type(12346787)
-        self.assertEqual(document_type, 'run')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="eol_sso",
-    version="0.0.1",
+    version="1.0.0",
     author="EOL Uchile",
     author_email="eol-ing@uchile.cl",
     description="Middleware between apps and uchileedxlogin/eol_sso_login",


### PR DESCRIPTION
Se modifica la funcion get_user_by_indiv_id para que efectivamente retorne el usuario asociado a algun indiv_id.
Se modifican los casos en donde eol_sso_login esta instalado en varias funciones, para que el comportamiento entre uchileedxlogin y eol_sso_login sean similares.
Nota: En la practica no son iguales ya que el tipo de dato DNI de eol_sso_login no va a ser soportado en eol_sso y no es soportado en uchileedxlogin y de igual manera, el tipo de indiv_id cg (cuentas genericas) no es soportado por eol_sso_login.
Se agregan y actualizan los tests.
